### PR TITLE
DEVOPS-409 replated set-outputs with writes to github env files

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Read ruby version
-        run: echo ::set-output name=RUBY_VERSION::$(cat .ruby-version | cut -f 1,2 -d .)
+        run: echo "RUBY_VERSION=$(cat .ruby-version | cut -f 1,2 -d .)" >> $GITHUB_OUTPUT
         id: rv
       - uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
## Proposed overview
The set-output and save-state functions in Github are being deprecated in favour of writing to environment files. They will lose their functionality on May 31, 2023. These changes are to capture the newer, recommended approach.

## Reference
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files

## Related tickets
DEVOPS-409